### PR TITLE
Support for dynamic joint limits

### DIFF
--- a/.github/workflows/industrial_ci_action.yml
+++ b/.github/workflows/industrial_ci_action.yml
@@ -17,10 +17,12 @@ jobs:
         env:
           - {ROS_DISTRO: foxy, ROS_REPO: main}
           - {ROS_DISTRO: foxy, ROS_REPO: testing}
-          - {ROS_DISTRO: rolling, ROS_REPO: main}
-          - {ROS_DISTRO: rolling, ROS_REPO: testing}
           - {ROS_DISTRO: galactic, ROS_REPO: main}
           - {ROS_DISTRO: galactic, ROS_REPO: testing}
+          - {ROS_DISTRO: humble, ROS_REPO: main}
+          - {ROS_DISTRO: humble, ROS_REPO: testing}
+          - {ROS_DISTRO: rolling, ROS_REPO: main}
+          - {ROS_DISTRO: rolling, ROS_REPO: testing}
 
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        distro: [foxy, galactic, rolling]
+        distro: [foxy, galactic, humble, rolling]
 
     env:
       ROS_DISTRO: ${{ matrix.distro }}

--- a/msg/OrientationConstraint.msg
+++ b/msg/OrientationConstraint.msg
@@ -9,6 +9,7 @@ geometry_msgs/Quaternion orientation
 string link_name
 
 # Tolerance on the three vector components of the orientation error (optional)
+# This is a total tolerance, e.g. (+ x_axis_tol / 2, - x_axis_tol / 2)
 float64 absolute_x_axis_tolerance
 float64 absolute_y_axis_tolerance
 float64 absolute_z_axis_tolerance


### PR DESCRIPTION
I created this PR in anticipation of two other PRs I have in the works for MoveIt and MTC so that they can support dynamic joint limit updates (specifically for vel/accel/jerk) in motion requests. This is useful when creating trajectories for arms that require restricted limits when being loaded vs when unloaded.
@AndyZe, @JafarAbdi